### PR TITLE
Fix parser not triggering when Chrome extension pastes data

### DIFF
--- a/index.html
+++ b/index.html
@@ -3719,8 +3719,31 @@
             const shipmentInput = document.getElementById('shipmentInput');
             if (shipmentInput) {
                  let parseTimer;
-                 shipmentInput.addEventListener('input', () => { clearTimeout(parseTimer); parseTimer = setTimeout(parseShipmentData, 300); });
+                 let lastValue = shipmentInput.value;
+                 const triggerParse = () => { clearTimeout(parseTimer); parseTimer = setTimeout(parseShipmentData, 300); };
+
+                 shipmentInput.addEventListener('input', triggerParse);
+                 shipmentInput.addEventListener('change', triggerParse);
+                 shipmentInput.addEventListener('paste', () => { setTimeout(parseShipmentData, 350); });
+                 shipmentInput.addEventListener('focus', () => {
+                     // Check if value changed while input was not focused (e.g., via extension)
+                     if (shipmentInput.value !== lastValue && shipmentInput.value.trim()) {
+                         lastValue = shipmentInput.value;
+                         triggerParse();
+                     }
+                 });
+                 shipmentInput.addEventListener('blur', () => {
+                     lastValue = shipmentInput.value;
+                 });
                  shipmentInput.addEventListener('scroll', saveShipmentInputScroll);
+
+                 // Check if extension pre-filled the input on page load
+                 setTimeout(() => {
+                     if (shipmentInput.value.trim() && shipmentInput.value !== lastValue) {
+                         lastValue = shipmentInput.value;
+                         triggerParse();
+                     }
+                 }, 500);
             }
             const upsUspsOutputArea = document.getElementById('upsUspsOutputArea');
             if(upsUspsOutputArea) {


### PR DESCRIPTION
Problem: Parser only listened to 'input' event, which doesn't fire when Chrome extensions programmatically set textarea values

Solution:
- Add 'change' event listener for form-based value changes
- Add 'paste' event listener for explicit paste actions
- Add 'focus' event listener to detect value changes made while input was unfocused
- Track last known value with 'blur' event listener
- Add 500ms delayed check on page load to catch pre-filled values from extensions

This ensures parsing triggers regardless of how the data enters the field: user typing, manual paste, extension auto-fill, or programmatic value setting